### PR TITLE
Change method to check for table existence

### DIFF
--- a/koans/start-here/02-migrations.rb
+++ b/koans/start-here/02-migrations.rb
@@ -134,7 +134,7 @@ dont_edit_this_bit do
       db.fetch(
         "SELECT * FROM pg_catalog.pg_tables 
         WHERE tablename = 'fruit'" 
-      ).all
+      ).first
     end
   end
 end


### PR DESCRIPTION
The method ```fruit_table_exists?(db)``` returns an empty array if the table does not exist. 

This is then used on line 41 to check whether the result is 'truthy'. 

It passes even if the table doesn't exist, I think that an empty array must be 'truthy', so I've changed the method to return the first element of the array which will be nil if it is empty.